### PR TITLE
update jsonpointer

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,17 +11,17 @@ with open(path.join(here, 'README.rst'), encoding='utf-8') as f:
 setup(
     name='sphinx-jsonschema',
     version='1.3',
-    
+
     description='Sphinx extension to display JSON Schema',
     long_description=long_description,
     url='https://github.com/lnoor/sphinx-jsonschema',
-    
+
     author='Leo Noordergraaf',
     author_email='leo@noordergraaf.net',
-    
+
     license='GPLv3',
     platforms='any',
-    
+
     classifiers=[
         'Development Status :: 4 - Beta',
         'Environment :: Plugins',
@@ -34,13 +34,12 @@ setup(
         'Topic :: Software Development :: Documentation',
         'Topic :: Documentation :: Sphinx'
     ],
-    
+
     keywords='sphinx json schema',
     packages=find_packages(),
     package_data={
         '': ['LICENSE']
     },
-    
-    install_requires=['docutils', 'requests', 'json-pointer']
+
+    install_requires=['docutils', 'requests', 'jsonpointer']
 )
-        

--- a/sphinx-jsonschema/__init__.py
+++ b/sphinx-jsonschema/__init__.py
@@ -3,19 +3,19 @@
 """
     sphinx-jsonschema
     -----------------
-    
+
     This package adds the *jsonschema* directive to Sphinx.
-    
+
     Using this directory you can render JSON Schema directly
     in Sphinx.
-    
+
     :copyright: Copyright 2017, Leo Noordergraaf
     :licence: GPL v3, see LICENCE for details.
 """
 
 import os.path
 import json
-import json_pointer
+from jsonpointer import resolve_pointer
 from collections import OrderedDict
 
 from docutils.parsers.rst import Directive
@@ -27,10 +27,10 @@ _glob_app = None
 class JsonSchema(Directive):
     optional_arguments = 1
     has_content = True
-    
+
     def __init__(self, directive, arguments, options, content, lineno, content_offset, block_text, state, state_machine):
         assert directive == 'jsonschema'
-        
+
         self.options = options
         self.state = state
         self.lineno = lineno
@@ -40,7 +40,7 @@ class JsonSchema(Directive):
             filename, pointer = self._splitpointer(arguments[0])
             self._load_external(filename)
             if pointer:
-                self.schema = json_pointer.Pointer(pointer).get(self.schema)
+                self.schema = resolve_pointer(self.schema, pointer)
         else:
             self._load_internal(content)
 


### PR DESCRIPTION
This PR removes the dependency on `json_pointer` and adds a dependency on `jsonpointer`, which AFAICT is a more well-maintained and tested json pointer package. This means `sphinx-jsonschema` can be used with python 3, yay!

And the deletions I think are extra whitespace that my editor automatically removed...can revert those if you want.