### PR TITLE
yaml support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,5 +41,5 @@ setup(
         '': ['LICENSE']
     },
 
-    install_requires=['docutils', 'requests', 'jsonpointer']
+    install_requires=['docutils', 'requests', 'jsonpointer', 'pyyaml']
 )


### PR DESCRIPTION
this adds support for yaml files, as it is common to store json schemas in the (more human readable) yaml format.  `pyyaml` should be able to read *both* JSON and yaml structures, so this is a quick way to handle both cases with minimal extra code.

The only extra addition is the function to ensure that the output is an ordered dict, which is a bit more involved than just using the json `OrderedDict` hook, but not too bad. LMK what you think.