### PR TITLE
Change that allows for type to be an array

### DIFF
--- a/sphinx-jsonschema/wide_format.py
+++ b/sphinx-jsonschema/wide_format.py
@@ -60,9 +60,9 @@ class WideFormat(object):
 
         if 'type' in schema:
             # select processor for type
-            if schema['type'] == 'object':
+            if 'object' in schema['type']:
                 rows = self._objecttype(schema)
-            elif schema['type'] == 'array':
+            elif 'array' in schema['type']:
                 rows = self._arraytype(schema)
             else:
                 rows = self._simpletype(schema)


### PR DESCRIPTION
Hi,

We have schemas that contain types that allow for a property to be an object OR null eg `"type": ["object", "null"]`. Similar for arrays. I noticed that these types didn't get recursed by JSON schema. This minor modification allows it to recurse the object props and array items if the type does happen to be an array like that.

Cheers,
Tom