### PR TITLE
Make PY3 compatible

### DIFF
--- a/sphinx-jsonschema/__init__.py
+++ b/sphinx-jsonschema/__init__.py
@@ -98,8 +98,8 @@ class JsonSchema(Directive):
             yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG,
             construct_mapping)
         try:
-            text = text.replace('\\(', '\\\\(')
-            text = text.replace('\\)', '\\\\)')
+            text = text.replace(b'\\(', b'\\\\(')
+            text = text.replace(b'\\)', b'\\\\)')
             try:
                 result = yaml.load(text, OrderedLoader)
             except yaml.scanner.ScannerError:


### PR DESCRIPTION
Without `b` prefix, `text.replace` fails with the error below

```exception:  a bytes-like object is required, not 'str'```