### PR TITLE
Major overhaul: added Definitions, auto target & reference and better error handling

### DIFF
--- a/docs/directive.rst
+++ b/docs/directive.rst
@@ -10,6 +10,8 @@ The schemas are read by a YAML parser.
 This means that you can write the schemas in either json or yaml notation
 and they will be processed identically.
 
+Useage
+------
 
 To display a schema fetched from a website:
 
@@ -119,5 +121,199 @@ which renders:
             "$$target": ["#/date"],
             "description": "YYYY-MM-DD",
             "type": "string"
+        }
+    }
+
+Options
+-------
+
+There a couple of options implemented into jsonschema that change the display or functionality of the schema.
+The options are:
+
+- seperate_description
+- seperate_definitions
+- enable_auto_target
+- enable_auto_reference
+
+Seperate Description
+++++++++++++++++++++
+
+To seperate the ``description`` from the table you will need to have a title defined and the 
+flag **\:seperate_description:** otherwise it will be included into the table:
+
+.. code-block::
+
+    .. jsonschema::
+        :seperate_description:
+
+        {
+            "$schema": "http://json-schema.org/draft-04/schema#",
+            "id": "http://example.com/schemas/example.json",
+            "title": "Example Seperate Description",
+            "description": "This is just a tiny example of a schema rendered by `sphinx-jsonschema <http://github.com/lnoor/sphinx-jsonschema>`_.\n\nWhereby the description can shown as text outside the table, and you can still use *reStructuredText* in a description.",
+            "type": "string",
+            "minLength": 10,
+            "maxLength": 100,
+            "pattern": "^[A-Z]+$"
+        }
+
+which renders:
+
+.. jsonschema::
+    :seperate_description:
+
+    {
+        "$schema": "http://json-schema.org/draft-04/schema#",
+        "id": "http://example.com/schemas/example.json",
+        "title": "Example Seperate Description",
+        "description": "This is just a tiny example of a schema rendered by `sphinx-jsonschema <http://github.com/lnoor/sphinx-jsonschema>`_.\n\nWhereby the description can shown as text outside the table, and you can still use *reStructuredText* in a description.",
+        "type": "string",
+        "minLength": 10,
+        "maxLength": 100,
+        "pattern": "^[A-Z]+$"
+    }
+
+Seperate Definitions
+++++++++++++++++++++
+
+To seperate the ``definitions`` from the table you will need to have the flag **\:seperate_description:** included. 
+For each item inside the ``definitions`` it will make a new section with title and a table of the items inside.
+It's advised to enable also **\:enable_auto_reference:** flag to auto link ``$ref`` to a local ``definitions`` title. 
+
+.. code-block:: rst
+
+    .. jsonschema::
+        :seperate_definitions:
+
+        {
+            "title": "Example with definitions",
+            "definitions": {
+                "football_player": {
+                    "type": "object",
+                    "required": ["first_name", "last_name", "age"],
+                    "properties": {
+                        "first_name": {"type": "string"},
+                        "last_name": {"type": "string"},
+                        "age": {"type": "integer"}
+                    }
+                },
+                "football_team": {
+                    "type": "object",
+                    "required": ["team", "league"],
+                    "properties": {
+                        "team": {"type": "string"},
+                        "league": {"type": "string"},
+                        "year_founded": {"type": "integer"}
+                    }
+                }
+            }
+        }
+
+which renders:
+
+.. jsonschema::
+    :seperate_definitions:
+
+    {
+        "title": "Example with definitions",
+        "definitions": {
+            "football_player": {
+                "type": "object",
+                "required": ["first_name", "last_name", "age"],
+                "properties": {
+                    "first_name": {"type": "string"},
+                    "last_name": {"type": "string"},
+                    "age": {"type": "integer"}
+                }
+            },
+            "football_team": {
+                "type": "object",
+                "required": ["team", "league"],
+                "properties": {
+                    "team": {"type": "string"},
+                    "league": {"type": "string"},
+                    "year_founded": {"type": "integer"}
+                }
+            }
+        }
+    }
+
+Auto Target and Reference
++++++++++++++++++++++++++
+
+With the **\:enable_auto_target:** flag there will be a target created with filename and optional pointer. 
+When you would include auto target on multiple JSON schema with identical filenames it will cause a conflict 
+within your build only the last build target will be used by the references. 
+this also applies if you would embed the schema directly into your documentation only the filename will be the document name.
+
+With the **\:enable_auto_reference:** flag there will be more logic applied to reduce the amount of undefined label warnings.
+It will check if it's referencing to it self and if there would be a title to link to,
+when there are titles in the same page that have an identical name it will cause linking issues. 
+If you didn't seperate definitions from the schema the ``$ref`` will become a text field without a linked reference.
+if the ``$ref`` would point to an other schema from the path it will extract the filename it expected 
+to be included into your documentation with a **\:enable_auto_target:**.
+
+Mainly the **\:enable_auto_reference:** flag infuence behavoir of the existing ``$$target`` methode and could potentially break links.
+
+| See below the schema whereby both options are included.
+  For each section it will create a target in this example filename of the document as the schema is added as context and it's pointer if there would be one.
+| :ref:`directive.rst` this link as raw text using reStructuredText format would be: **\:ref:`directive.rst`**.
+| And for the definition :ref:`directive.rst#/definitions/person` the raw text would be:  **\:ref:`directive.rst#/definitions/person`**.
+
+.. code-block:: rst
+
+    .. jsonschema::
+        :seperate_definitions:
+        :enable_auto_reference:
+        :enable_auto_target:
+
+    {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title":  "Example of Target & Reference",
+        "type": "object",
+        "properties": {
+            "person": { "$ref": "#/definitions/person" }
+        },
+        "definitions": {
+            "person": {
+                "type": "object",
+                "properties": {
+                    "name": { "type": "string" },
+                    "children": {
+                        "type": "array",
+                        "items": { "$ref": "#/definitions/person" },
+                        "default": []
+                    }
+                }
+            }
+        }
+    }
+
+which renders:
+
+.. jsonschema::
+    :seperate_definitions:
+    :enable_auto_reference:
+    :enable_auto_target:
+
+    {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "Example of Target & Reference",
+        "type": "object",
+        "properties": {
+            "person": { "$ref": "#/definitions/person" }
+        },
+        "definitions": {
+            "person": {
+                "type": "object",
+                "properties": {
+                    "name": { "type": "string" },
+                    "children": {
+                        "type": "array",
+                        "items": { "$ref": "#/definitions/person" },
+                        "default": []
+                    }
+                }
+            }
         }
     }

--- a/sphinx-jsonschema/__init__.py
+++ b/sphinx-jsonschema/__init__.py
@@ -22,8 +22,6 @@ from collections import OrderedDict
 from docutils.parsers.rst import Directive
 from .wide_format import WideFormat
 
-# TODO find out if app is accessible in some other way
-_glob_app = None
 
 class JsonSchema(Directive):
     optional_arguments = 1
@@ -51,7 +49,7 @@ class JsonSchema(Directive):
             self._load_internal(content)
 
     def run(self):
-        format = WideFormat(self.state, self.lineno, _glob_app)
+        format = WideFormat(self.state, self.lineno, self.state.document.settings.env.app)
         return format.transform(self.schema)
 
     def _load_external(self, file_or_url):
@@ -113,7 +111,5 @@ class JsonSchema(Directive):
 
 
 def setup(app):
-    global _glob_app
-    _glob_app = app
     app.add_directive('jsonschema', JsonSchema)
     return {'version': '1.15'}

--- a/sphinx-jsonschema/__init__.py
+++ b/sphinx-jsonschema/__init__.py
@@ -16,7 +16,7 @@
 import os.path
 import json
 from jsonpointer import resolve_pointer
-from traceback import format_exception
+from traceback import format_exception, format_exception_only
 import yaml
 from collections import OrderedDict
 

--- a/sphinx-jsonschema/__init__.py
+++ b/sphinx-jsonschema/__init__.py
@@ -128,7 +128,7 @@ class JsonSchema(Directive):
         except Exception as error:
             error = self.state_machine.reporter.error(
                     '"%s" directive encountered a the following error while parsing the data, %s'
-                     % (self.name, SafeString(format_exception_only(type(error), error),
+                     % (self.name, SafeString(format_exception_only(type(error), error))),
                     nodes.literal_block(schema, schema), line=self.lineno)
             raise SystemMessagePropagation(error)
         

--- a/sphinx-jsonschema/__init__.py
+++ b/sphinx-jsonschema/__init__.py
@@ -79,8 +79,8 @@ class JsonSchema(Directive):
             schema = self.ordered_load(schema)
         except Exception as error:
             error = self.state_machine.reporter.error(
-                    '"%s" directive encountered a the following error while parsing the data, %s'
-                     % (self.name, SafeString(format_exception_only(type(error), error))),
+                    '"%s" directive encountered a the following error while parsing the data.\n %s'
+                     % (self.name, SafeString("".join(format_exception_only(type(error), error)))),
                     nodes.literal_block(schema, schema), line=self.lineno)
             raise SystemMessagePropagation(error)
         

--- a/sphinx-jsonschema/__init__.py
+++ b/sphinx-jsonschema/__init__.py
@@ -93,10 +93,6 @@ class JsonSchema(Directive):
                     ' in schema: %s' % (self.name, SafeString(pointer)),
                     nodes.literal_block(schema, schema), line=self.lineno)
                 raise SystemMessagePropagation(error)
-            
-            # add '#' in front for further useage for file target
-            # resove_pointer can't handle the '#'
-            pointer = '#' + pointer
 
         return schema, source, pointer
 

--- a/sphinx-jsonschema/wide_format.py
+++ b/sphinx-jsonschema/wide_format.py
@@ -213,8 +213,11 @@ class WideFormat(object):
             if k in schema:
                 items = []
                 for s in schema[k]:
-                    items.extend(self._dispatch(s, self._cell('-'))[0])
-                rows.extend(self._prepend(self._cell(k), items))
+                    content = self._dispatch(s)[0]
+                    if content:
+                        items.extend(self._prepend(self._cell('-'), content))
+                if items:
+                    rows.extend(self._prepend(self._cell(k),items))
                 del schema[k]
 
         for k in self.SINGLEOBJECTS:

--- a/sphinx-jsonschema/wide_format.py
+++ b/sphinx-jsonschema/wide_format.py
@@ -392,7 +392,7 @@ class WideFormat(object):
             elif "#/" in schema['$ref']:
                 row = (self._line(self._cell(':ref:`' + self._get_filename(schema['$ref'], True) + '`')))
             else:
-                row = (self._line(self._cell(':ref:`' + self._get_filename(schema['$ref']) + '#/`')))
+                row = (self._line(self._cell(':ref:`' + self._get_filename(schema['$ref']) + '`')))
         else:
             row = (self._line(self._cell(':ref:`' + schema['$ref'] + '`')))
         del schema['$ref']

--- a/tests/test_overall.py
+++ b/tests/test_overall.py
@@ -11,12 +11,14 @@ wide_format = __import__('sphinx-jsonschema.wide_format')
 
 @pytest.fixture
 def wideformat():
-    state = Body(RSTStateMachine(None, None))
-    #state = Mock()
+    state = Body(RSTStateMachine([], None))
+    state.build_table = Mock()
     lineno = 1
+    source = ''
+    options = {}
     app = None
 
-    return wide_format.WideFormat(state, lineno, app)
+    return wide_format.WideFormat(state, lineno, source, options, app)
 
 def test_create(wideformat):
     wf = wideformat
@@ -24,10 +26,14 @@ def test_create(wideformat):
 
 def test_string(wideformat):
     schema = {
-        '$id': 'somewhere',
-        'title': 'Just a String',
-        'description': 'just another boring string',
-        'type': 'string'
+        "$schema": "http://json-schema.org/draft-04/schema#",
+        "title": "An example",
+        "id": "http://example.com/schemas/example.json",
+        "description": "This is just a tiny example of a schema rendered by `sphinx-jsonschema <http://github.com/lnoor/sphinx-jsonschema>`_.\n\nYes that's right you can use *reStructuredText* in a description.",
+        "type": "string",
+        "minLength": 10,
+        "maxLength": 100,
+        "pattern": "^[A-Z]+$"
     }
     result = wideformat.transform(schema)
-    #wideformat.state.build_table.assert_called()
+    wideformat.state.build_table.assert_called()


### PR DESCRIPTION
Hi,

I have changed the following items:
* Removed  init from JsonSchema now using parent init of Directive
* Created a single function replacing the _load_external & _load_internal functions to load the json schema
* Implemented multiple exceptions separately to return better guiding to the error
  * The generated messages are handled by docutils to be printed
* In wide_format new function run, target, section, get_description, definitions, reference have been added
  * The function run has become the new entry point to build the schema
  * The function wrap_in_section has been removed but moved to target and section
* Added documentation with the options that have been added
* Updated the test

A snapshot of the documentation showing how the definitions would render now:
<img width="526" alt="chrome-200828-220854-751" src="https://user-images.githubusercontent.com/64363740/91611264-2937e680-e97b-11ea-8be0-9b9a9ea9417e.png">

This would include improvements regarding issues: #23, #39 and #40

Greeting