### PR TITLE
escape strings in _render_any_value

### DIFF
--- a/sphinx-jsonschema/wide_format.py
+++ b/sphinx-jsonschema/wide_format.py
@@ -545,6 +545,8 @@ class WideFormat(object):
             else:
                 for k in value:
                     rows.extend(self._prepend(self._cell(k), self._render_any_value(value[k])))
+        elif isinstance(value, str):
+            rows.append(self._line(self._cell(self._escape(value) if value is not None else "null")))
         else:
             rows.append(self._line(self._cell(value if value is not None else "null")))
         return rows


### PR DESCRIPTION
I was trying to use Sphinx-jsonschema to render a schema that contains a default value as a string ending with an `_` this causes 
sphinx to interpret it as a link and attempt to find a reference for that string which fails. 

I am not sure if this is the best way to fix that but escaping any string in `_render_any_value` resolves the issue for me
