### PR TITLE
New option "encoding" for parsing schemas from file.

### DIFF
--- a/sphinx-jsonschema/__init__.py
+++ b/sphinx-jsonschema/__init__.py
@@ -47,7 +47,8 @@ class JsonSchema(Directive):
                    'lift_definitions': flag,
                    'auto_reference': flag,
                    'auto_target': flag,
-                   'timeout': float}
+                   'timeout': float,
+                   'encoding': directives.encoding}
 
     def run(self):
         try:
@@ -159,7 +160,7 @@ class JsonSchema(Directive):
             source = filename
 
         try:
-            with open(source) as file:
+            with open(source, encoding=self.options.get('encoding')) as file:
                 data = file.read()
         except IOError as error:
             raise self.error(u'"%s" directive encountered an IOError while loading file: %s\n%s'


### PR DESCRIPTION
Hello! Faced the issue with encodings while working on documentation on russian version of windows, which uses cp1251 as it's standard encoding. 

json-schema always uses locale encoding when opening json file, which may cause some problems like inablity to parse file altogether or making a mess instead of readable characters if json file is saved as utf8 instead of locale encoding (for e.g. downloaded from internet or created using some sophisticated program)

To reproduce I suggest you to try this file **product.schema**, which content is:

```json
{
    "$schema": "https://json-schema.org/draft/2019-09/schema",
    "title": "Описание свойств продукта",
    "type": "object",
    "properties": {
        "id": {"description": "Уникальный идентификатор продукта", "type": "str"},
    }
}
```
File contents is saved in utf8 encoding 

Now if you try to render a schema on windows, which default encoding is not utf8 but cp1251, you'll end up with this mess (which is not actual russian letters btw:) :

![изображение](https://user-images.githubusercontent.com/53076075/123127464-fa7f8500-d452-11eb-8448-9e3fa8ccce45.png)

But if we add one more property, which has a byte in utf8 which is not in code table of cp1251:

```json
{
    "$schema": "https://json-schema.org/draft/2019-09/schema",
    "title": "Описание свойств продукта",
    "type": "object",
    "properties": {
        "id": {"description": "Уникальный идентификатор продукта", "type": "str"},
        "source": {"description": "Источник поступления продукта", "type": "str"}
    }
}
```

 we will get an error:

![изображение](https://user-images.githubusercontent.com/53076075/123129495-a70e3680-d454-11eb-8f65-29250cca387e.png)


It happens because sphinx-jsonschema tries to open file using locale encoding, in my case it is cp1251 (standard encoding for russian versions of windows), which sometimes have bytes which map to correct cp1251 symbols but sometimes it doesn't. 

When writing documentation, my solution was to save file in cp1251 encoding, but I think having sphinx-jsonschema to handle it semi-automatically will be nice, so I implemented a simple solution which adds an option for encoding, which is expected to be used like this

```
.. json_schema:: product.schema
    :encoding: utf8
```

which will make sphinx-jsonschema to open file in specified encoding, instead of system one.

This way, "default" functionality hasn't changed, file is being opened using system encoding, but for users with system encoding which differes from utf8 encoding there will be no such problems as having a need to re-encode files with schemas.


**Or,** instead of all of that we can open files as utf8 by default or leave it for the users, to use correct encoding for files. 