### PR TITLE
#71 handle schema defined in Python object

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -60,15 +60,20 @@ Display a schema located in a file with an absolute path::
 
     .. jsonschema:: /home/leo/src/jsonschema/sample.json
 
-Or a path relative to the referencing document::
+A path relative to the referencing document::
 
     .. jsonschema:: jsonschema/sample.json
+
+Or a schema defined in a python dict::
+
+    .. jsonschema:: mod.pkg.SCHEMA
 
 With all three of the above you may add JSON Pointer notation to display a subschema::
 
     .. jsonschema:: http://some.domain/with/a/path/spec.json#/path/to/schema
     .. jsonschema:: /home/leo/src/jsonschema/sample.json#/path/to/schema
     .. jsonschema:: jsonschema/sample.json#/path/to/schema
+    .. jsonschema:: mod.pkg.SCHEMA#/path/to/schema
 
 Alternatively you can embed the schema::
 

--- a/README.rst
+++ b/README.rst
@@ -64,7 +64,7 @@ A path relative to the referencing document::
 
     .. jsonschema:: jsonschema/sample.json
 
-Or a schema defined in a python dict::
+Or a schema defined in a Python object::
 
     .. jsonschema:: mod.pkg.SCHEMA
 

--- a/docs/directive.rst
+++ b/docs/directive.rst
@@ -124,6 +124,32 @@ which renders:
         }
     }
 
+Lastly, you can use the ``jsonschema`` directive to render a schema from a Python
+object:
+
+.. code-block:: python
+    :caption: ``example.py``
+
+        SCHEMA = {
+            "$schema": "http://json-schema.org/draft-04/schema#",
+            "title": "An example",
+            "id": "http://example.com/schemas/example.json",
+            "description": "This is just a tiny example of a schema rendered by `sphinx-jsonschema <http://github.com/lnoor/sphinx-jsonschema>`_.\n\nYes that's right you can use *reStructuredText* in a description.",
+            "type": "string",
+            "minLength": 10,
+            "maxLength": 100,
+            "pattern": "^[A-Z]+$"
+        }
+
+with the following usage of the directive:
+.. code-block:: rst
+
+    .. jsonschema:: sphinx-jsonschema.example.SCHEMA
+
+which should render as:
+
+.. jsonschema:: sphinx-jsonschema.example.SCHEMA
+
 Options
 -------
 

--- a/docs/directive.rst
+++ b/docs/directive.rst
@@ -142,13 +142,14 @@ object:
         }
 
 with the following usage of the directive:
+
 .. code-block:: rst
 
     .. jsonschema:: sphinx-jsonschema.example.SCHEMA
 
 which should render as:
 
-.. jsonschema:: sphinx_jsonschema.example.SCHEMA
+.. jsonschema:: sphinx-jsonschema.example.SCHEMA
 
 Options
 -------
@@ -393,7 +394,9 @@ The ``conf.py`` option **jsonschema_options** lets you do so.
 It takes a dict as value the boolean valued keys of which have the same name as the options.
 
 So, in ``conf.py`` you can state:
-.. code-block:: py
+
+.. code-block:: python
+    :caption: ``conf.py``
 
     jsonschema_options = {
         'lift_description': True,

--- a/docs/directive.rst
+++ b/docs/directive.rst
@@ -151,6 +151,11 @@ which should render as:
 
 .. jsonschema:: sphinx-jsonschema.example.SCHEMA
 
+.. important::
+    For rendering Python objects with the ``jsonschema`` directive, the object does not
+    *need* to be a dict or a string. However, the object must have a ``__str__`` method
+    defined that will return a valid schema.
+
 Options
 -------
 

--- a/docs/directive.rst
+++ b/docs/directive.rst
@@ -148,7 +148,7 @@ with the following usage of the directive:
 
 which should render as:
 
-.. jsonschema:: sphinx-jsonschema.example.SCHEMA
+.. jsonschema:: sphinx_jsonschema.example.SCHEMA
 
 Options
 -------

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open(path.join(here, 'README.rst'), encoding='utf-8') as f:
 
 setup(
     name='sphinx-jsonschema',
-    version='1.18.0',     # don't forget: must match __init__.py::setup() return value
+    version='1.19.0',     # don't forget: must match __init__.py::setup() return value
 
     description='Sphinx extension to display JSON Schema',
     long_description=long_description,

--- a/sphinx-jsonschema/__init__.py
+++ b/sphinx-jsonschema/__init__.py
@@ -334,7 +334,7 @@ class JsonSchema(Directive):
         else:
             raise self.error(
                 f"{self.name} directive requires a Python reference to a schema object"
-                " like 'mod.pkg.data'."
+                f" like 'mod.pkg.data'. '{filename}' is not valid."
             )
 
         try:

--- a/sphinx-jsonschema/__init__.py
+++ b/sphinx-jsonschema/__init__.py
@@ -339,7 +339,7 @@ class JsonSchema(Directive):
 
         try:
             mod = importlib.import_module(module_name)
-            data = getattr(mod, obj_name)
+            data = str(getattr(mod, obj_name))
         except (ImportError, ModuleNotFoundError) as error:
             raise self.error(
                 f"{self.name} directive encountered an error while importing python"

--- a/sphinx-jsonschema/example.py
+++ b/sphinx-jsonschema/example.py
@@ -1,0 +1,10 @@
+SCHEMA = {
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "title": "An example",
+    "id": "http://example.com/schemas/example.json",
+    "description": "This is just a tiny example of a schema rendered by `sphinx-jsonschema <http://github.com/lnoor/sphinx-jsonschema>`_.\n\nYes that's right you can use *reStructuredText* in a description.",
+    "type": "string",
+    "minLength": 10,
+    "maxLength": 100,
+    "pattern": "^[A-Z]+$"
+}


### PR DESCRIPTION
This PR is to support #71 such that python objects can be referenced directly. The limitation here is that you can not point to a python file as the python module must be in scope. For most Tox environments, this will be the case for generating documentation. 

One thing I noticed is that [here](https://github.com/lnoor/sphinx-jsonschema/blob/bf3a295ca655e815e6d17d2cec69092469bf56c3/sphinx-jsonschema/__init__.py#L235-L242), the sphinx-build command did not display the exception message by default. I'm not sure if that was due to a filter or configuration in `conf.py`, but I haven't looked too close as that seemed outside the scope of this PR. 