### PR TITLE
Fix checking for relative paths

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,9 +31,6 @@ setup(
         'License :: OSI Approved :: GNU General Public License v3 (GPLv3)',
         'Operating System :: OS Independent',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.8',
-        'Programming Language :: Python :: 3.9',
-        'Programming Language :: Python :: 3.10',
         'Topic :: Software Development :: Documentation',
         'Topic :: Documentation :: Sphinx'
     ],

--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,9 @@ setup(
         'License :: OSI Approved :: GNU General Public License v3 (GPLv3)',
         'Operating System :: OS Independent',
         'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
         'Topic :: Software Development :: Documentation',
         'Topic :: Documentation :: Sphinx'
     ],

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,6 @@ setup(
 
     license='GPLv3',
     platforms='any',
-    python_requires='>=3.8',
 
     classifiers=[
         'Development Status :: 4 - Beta',

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,7 @@ setup(
 
     license='GPLv3',
     platforms='any',
+    python_requires='>=3.8',
 
     classifiers=[
         'Development Status :: 4 - Beta',

--- a/sphinx-jsonschema/__init__.py
+++ b/sphinx-jsonschema/__init__.py
@@ -228,9 +228,9 @@ class JsonSchema(Directive):
         elif filename and filename.startswith('http'):
             # Appears to be URL so process it as such
             schema, source = self.from_url(filename)
-        elif os.path.exists(source := self._convert_filename(filename)):
+        elif os.path.exists(self._convert_filename(filename)):
             # File exists so it must be a JSON schema
-            schema, source = self.from_file(source)
+            schema, source = self.from_file(filename)
         elif filename:
             # Must be a Python reference to a schema
             schema, source = self.from_data(filename)
@@ -311,7 +311,8 @@ class JsonSchema(Directive):
         document_source = os.path.dirname(self.state.document.current_source)
         return os.path.join(document_source, filename)
 
-    def from_file(self, source):
+    def from_file(self, filename):
+        source = self._convert_filename(filename)
         try:
             with open(source, encoding=self.options.get('encoding')) as file:
                 data = file.read()

--- a/sphinx-jsonschema/__init__.py
+++ b/sphinx-jsonschema/__init__.py
@@ -228,9 +228,9 @@ class JsonSchema(Directive):
         elif filename and filename.startswith('http'):
             # Appears to be URL so process it as such
             schema, source = self.from_url(filename)
-        elif os.path.exists(filename):
+        elif os.path.exists(source := self._convert_filename(filename)):
             # File exists so it must be a JSON schema
-            schema, source = self.from_file(filename)
+            schema, source = self.from_file(source)
         elif filename:
             # Must be a Python reference to a schema
             schema, source = self.from_data(filename)
@@ -301,14 +301,17 @@ class JsonSchema(Directive):
         data = response.content.decode()
         return data, url
 
-    def from_file(self, filename):
+    def _convert_filename(self, filename):
+        """
+        Join the filename with the docs' source if it is not absolute.
+        """
+        if os.path.isabs(filename):
+            return filename
+        # file relative to the path of the current rst file
         document_source = os.path.dirname(self.state.document.current_source)
-        if not os.path.isabs(filename):
-            # file relative to the path of the current rst file
-            source = os.path.join(document_source, filename)
-        else:
-            source = filename
+        return os.path.join(document_source, filename)
 
+    def from_file(self, source):
         try:
             with open(source, encoding=self.options.get('encoding')) as file:
                 data = file.read()
@@ -317,6 +320,7 @@ class JsonSchema(Directive):
                              % (self.name, source, error))
 
         # Simplifing source path and to the document a new dependency
+        document_source = os.path.dirname(self.state.document.current_source)
         source = utils.relative_path(document_source, source)
         self.state.document.settings.record_dependencies.add(source)
 


### PR DESCRIPTION
fixes #76

- ~I am using python ~3.10~ 3.8 syntax with `source := self._convert_filename(filename)`, please let me know what you'd prefer if you don't want this~
  - 3.8+ syntax removed
- I don't know how to run your tests. I tried to run `tox` but ran into this:
```python
======================================= ERRORS ========================================
____________________________ ERROR at setup of test_create ____________________________

    @pytest.fixture
    def wideformat():
        ...
>       return wide_format.WideFormat(state, lineno, source, options, app)

tests/test_overall.py:21: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

    def __init__(self, state, lineno, source, options, app):
        ...
>       self.options.update(app.config.jsonschema_options)
E       AttributeError: 'NoneType' object has no attribute 'config'

.tox/py38/lib/python3.8/site-packages/sphinx-jsonschema/wide_format.py:64: AttributeError
```
  - I tried to add some `Mock`s to the `app` being passed, but then ran into this
```python
wideformat = <sphinx-jsonschema.wide_format.WideFormat object at 0x7fa9b5e106d0>

    def test_string(wideformat):
        ...
>       result = wideformat.transform(schema)

tests/test_overall.py:39: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

    def _convert_content(self, text):
        ...
>       items = [(self.state.document.current_source, self.lineno)] * len(list_lines)
E       AttributeError: 'Body' object has no attribute 'document'

.tox/py38/lib/python3.8/site-packages/sphinx-jsonschema/wide_format.py:622: AttributeError
```
